### PR TITLE
Style fix

### DIFF
--- a/projects/angular-feather/src/lib/feather.component.scss
+++ b/projects/angular-feather/src/lib/feather.component.scss
@@ -1,5 +1,5 @@
-:host {
-  display: block;
+:host svg {
+  display: inline-block;
   width: 24px;
   height: 24px;
   fill: none;

--- a/projects/angular-feather/src/lib/feather.component.scss
+++ b/projects/angular-feather/src/lib/feather.component.scss
@@ -1,5 +1,5 @@
 :host {
-  display: inline-block;
+  display: block;
   width: 24px;
   height: 24px;
   fill: none;

--- a/projects/angular-feather/src/lib/feather.component.scss
+++ b/projects/angular-feather/src/lib/feather.component.scss
@@ -1,5 +1,4 @@
 :host svg {
-  display: inline-block;
   width: 24px;
   height: 24px;
   fill: none;


### PR DESCRIPTION
I had differences of positioning and spacing using the library.

With the library:
![image](https://github.com/michaelbazos/angular-feather/assets/1771574/346a4dc9-0c75-453a-b59c-e61afe28d21a)

Without it:
![image](https://github.com/michaelbazos/angular-feather/assets/1771574/99650aed-d279-47aa-afe4-1a08ce104fe4)

I found that the component is styling the host element instead of the svg